### PR TITLE
NEM: fix mosaic caluclation

### DIFF
--- a/component/nem.js
+++ b/component/nem.js
@@ -119,44 +119,12 @@ module.exports=require("../js/lang.js")({ja:require("./ja/nem.html"),en:require(
       nem.com.requests.account.mosaics.owned(endpoint,this.address).then(b=>{
         this.loading=false
         return Promise.all(b.data.map(mos=>{
-          if(mos.mosaicId.namespaceId==="nem"){
-            return Promise.resolve({
-              definitions:{
-                "creator": "3e82e1c1e4a75adaa3cba8c101c3cd31d9817a2eb966eb3b511fb2ed45b8e262",
-                "description": "reserved xem mosaic",
-                "id": {
-                  "namespaceId": "nem",
-                  "name": "xem"
-                },
-                "properties": [{
-                  "name": "divisibility",
-                  "value": "6"
-                }, {
-                  "name": "initialSupply",
-                  "value": "8999999999"
-                }, {
-                  "name": "supplyMutable",
-                  "value": "false"
-                }, {
-                  "name": "transferable",
-                  "value": "true"
-                }],
-                "levy": {}
-              },
-              quantity:mos.quantity,
-              mosaicId:mos.mosaicId,
-              divisibility:6,
-              normalizedQty:(new BigNumber(mos.quantity)).shift(-6).toNumber(),
-              icon:icons["nem:xem"]
-            })
-          }
-          
           let divisibility=6;
           let mData
-          return nem.com.requests.namespace.mosaicDefinitions(endpoint,mos.mosaicId.namespaceId).then(def=>{
+          return nem.com.requests.account.mosaics.allDefinitions(endpoint, this.address).then(def=>{
             
             for(let i=0;i<def.data.length;i++){
-              mData=def.data[i].mosaic
+              mData=def.data[i]
               if(mData.id.name!==mos.mosaicId.name){
                 continue
               }


### PR DESCRIPTION
Issue #27 の修正。

nem.com.requests.namespace.mosaicDefinitionsでは、モザイク定義が最大25種類しか返ってこないため、26種類以上モザイクを作成しているネームスペースに対して叩くと、全てのモザイク定義が返ってこない。

そのため、nem.com.requests.account.mosaics.allDefinitionsを利用して、自身のアカウントが持つ各モザイクの定義を取得するように変更する。

※備考
nem.com.requests.account.mosaics.allDefinitionsが実際に叩いてるAPI(/account/mosaic/owned/definition)についての説明が、NIS APIのドキュメントに存在しない気がする......
https://github.com/QuantumMechanics/NEM-sdk/blob/master/src/com/requests/account.js#L270
https://nemproject.github.io

そのため、所有しているモザイクについて、正しく全種類の結果が返ってくるのか？という疑問が残る。
実動作としては、テストネット上で確認したところ、少なくとも26種類以上は返してきて、もにゃ内でも正しく取得・解釈できている。
http://23.228.67.85:7890/account/mosaic/owned/definition?address=TBI2E2Z6LBLB6NNQEEUXW5NBYXL4NOIUHOBS5FKB
![default](https://user-images.githubusercontent.com/2842469/39587504-a834c658-4f34-11e8-901f-536eb933a023.PNG)
