### PR TITLE
Make it possible to display transaction message in utf8 and hex

### DIFF
--- a/component/txDetail.html
+++ b/component/txDetail.html
@@ -13,9 +13,10 @@
             <v-ons-input v-model="txLabel" placeholder="名称未設定" @change="saveTxLabel"></v-ons-input>
           </div>
         </v-ons-list-item>
-        <v-ons-list-item v-show="!decodedCPMessage">
+        <v-ons-list-item v-show="!decodedCPMessage" @click="messageBinary=!messageBinary">
           <div class="center">メッセージ</div>
-          <div class="right" v-if="message">{{message}}</div>
+          <div class="right" v-if="message&&messageBinary">{{message}}</div>
+          <div class="right" v-if="message&&!messageBinary">{{hexMessage}}</div>
           <div class="right" v-if="!message">(メッセージ無し)</div>
         </v-ons-list-item>
         <v-ons-list-item v-show="decodedCPMessage">

--- a/component/txDetail.js
+++ b/component/txDetail.js
@@ -29,12 +29,14 @@ module.exports=require("../js/lang.js")({ja:require("./ja/txDetail.html"),en:req
     return {
       res:null,
       message:"",
+      hexMessage:"",
       fiat:this.$store.state.fiat,
       coinId:this.$store.state.detail.coinId,
       price:0,
       txId:this.$store.state.detail.txId,
       txLabel:"",
       showScript:false,
+      messageBinary:true,
       decodedCPMessage:null
     }
   },
@@ -49,8 +51,11 @@ module.exports=require("../js/lang.js")({ja:require("./ja/txDetail.html"),en:req
       const txProm = cur.getTx(this.txId).then(v=>{
         this.res=v
         v.vout.forEach(o=>{
-          if(o.scriptPubKey.hex&&o.scriptPubKey.hex.substr(0,2)==="6a"){
-            this.message=bcLib.script.nullData.output.decode(new Buffer(o.scriptPubKey.hex,"hex")).toString('utf8')
+          const hexScript=o.scriptPubKey.hex
+          if(hexScript&&hexScript.substr(0,2)==="6a"){
+            const decoded=bcLib.script.nullData.output.decode(new Buffer(hexScript,"hex"))
+            this.message=decoded.toString('utf8')
+            this.hexMessage=decoded.toString('hex')
           }
         })
       })


### PR DESCRIPTION
トランザクションのOP_RETURNをhex表示できるように (例示のものはSegWitコミットメント)
![デフォルト](https://user-images.githubusercontent.com/10355528/55458888-2a030680-5629-11e9-8344-3dea67a5cc63.png)
![hex](https://user-images.githubusercontent.com/10355528/55458892-2bccca00-5629-11e9-8b4c-264f77ce252e.png)
