### PR TITLE
Fix getTx() for Blockbook

### DIFF
--- a/js/explorers/blockbook.js
+++ b/js/explorers/blockbook.js
@@ -44,14 +44,15 @@ module.exports = class BlockbookExplorer {
                 // add asm
                 vin.scriptSig.asm = bitcoin.script.toASM(Buffer.from(vin.scriptSig.hex, 'hex'));
                 // convert value to satoshis/watanabes
-                data.valueSat = +new BigNumber(data.value).times(100000000);
+                data.valueSat = +new BigNumber(vin.value).times(100000000);
                 // and to decimal
-                data.value = +data.value;
+                data.value = +vin.value;
             }
             for (let vout of data.vout) {
                 // add asm
                 vout.scriptPubKey.asm = bitcoin.script.toASM(Buffer.from(vout.scriptPubKey.hex, 'hex'));
             }
+            return data;
         });
     }
 


### PR DESCRIPTION
Fix a bug that getTx () fails when only Blockbook explorer is set