### PR TITLE
Update monacoin's WIF key

### DIFF
--- a/js/currencyList.js
+++ b/js/currencyList.js
@@ -70,7 +70,7 @@ const defaultCoins = [{
     },
     pubKeyHash: 50,
     scriptHash: 55,
-    wif: 178, //new wif
+    wif: 176, //new wif
     bech32: "mona"
   },
   sound: require("../res/coins/paySound/mona.m4a"),


### PR DESCRIPTION
MonacoinのWIFキーはどのバージョン(確か0.10辺り)か忘れましたが、178から176に更新されています。
一応Qt or coindではどちらも読み込むようになっていますが、こちらが新しいものになっていますので更新をお願いします。
https://github.com/monacoinproject/monacoin/blob/master-0.16/src/chainparams.cpp#L143