### PR TITLE
Fix token info fetching from Monacard

### DIFF
--- a/js/title.js
+++ b/js/title.js
@@ -95,30 +95,29 @@ module.exports = class {
     }
     const promises = _.chunk(token, 20)
       .map(ss => ss.join(","))
-      .map(tok => {
-        return axios
+      .map(tok =>
+        axios
           .get(this.apiEndpoint + "/card_detail.php?assets=" + tok)
-          .then(r => {
-            const arr = [];
-            if (!r.data.error) {
-              r.data.details.forEach(k => {
-                arr.push({
-                  description: k.add_description,
-                  asset: k.asset,
-                  assetCommonName: k.asset_common_name,
-                  assetLongName: k.asset_longname,
-                  cardName: k.card_name,
-                  imageUrl: k.imgur_url,
-                  ownerName: k.owner_name,
-                  twitterId: k.tw_id,
-                  twitterScreenName: k.tw_name,
-                  timestamp: parseInt(k.update_time, 10)
-                });
-              });
-            } //error but ignore because other promise stop
-            return arr;
-          });
-      });
+          .then(({ data }) => {
+            // ignore errors to prevent from stopping other promise
+            if (!data.error) {
+              return data.details.map(k => ({
+                description: k.add_description,
+                asset: k.asset,
+                assetCommonName: k.asset_common_name,
+                assetLongName: k.asset_longname,
+                cardName: k.card_name,
+                imageUrl: k.imgur_url,
+                ownerName: k.owner_name,
+                twitterId: k.tw_id,
+                twitterScreenName: k.tw_name,
+                timestamp: parseInt(k.update_time, 10)
+              }));
+            } else {
+              return [];
+            }
+          })
+      );
     return Promise.all(promises).then(_.flatten);
   }
   getCardDetailV2(token) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cordova-plugin-qrscanner": "^2.5.0",
     "ethereumjs-wallet": "^0.6.0",
     "instascan": "^1.0.0",
+    "lodash": "^4.17.15",
     "nem-sdk": "^1.6.4",
     "onsenui": "^2.10.0",
     "pump": "^2.0.0",


### PR DESCRIPTION
トークンがモリモリなアドレスがウォレットにある時、Monacard情報を一斉に問い合わせると、Monacardが応答しないので分割してリクエストするように (1リクエスト当たり20トークンまで)    
再現アドレス: MNbmg3KbWqkksvJFZkUJ8WTeqZ1i1gu2Xz