### PR TITLE
Update VIPSTARCOIN explorer

### DIFF
--- a/js/currencyList.js
+++ b/js/currencyList.js
@@ -349,8 +349,13 @@ const defaultCoins = [
     icon: require("../res/coins/vips.png"),
     apiEndpoints: [
       {
-        url: "https://insight.vipstarco.in/api",
-        explorer: "https://insight.vipstarco.in",
+        url: "https://insight.vipstarcoin.jp/api",
+        explorer: "https://insight.vipstarcoin.jp",
+        type: "insight"
+      },
+      {
+        url: "https://insight.nezirin.net/api",
+        explorer: "https://insight.nezirin.net",
         type: "insight"
       },
       {


### PR DESCRIPTION
VIPSTARCOINのexplorerのリストの更新です。
・insight.vipstarco.inの管理者と連絡が取れないため削除
・insight.vipstarcoin.jpを追加（VIPS社サーバー、管理者： @takana-v）
・insight.nezirin.netを追加（管理者：ねじりん#2246）